### PR TITLE
Add `html.haml` as a possible file type

### DIFF
--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -5,7 +5,7 @@
       "camelcase": "Haml",
       "scope": "source.haml",
       "path": ".",
-      "file-types": ["haml"],
+      "file-types": ["html.haml", "haml"],
       "injection-regex": "^haml$"
     }
   ],


### PR DESCRIPTION
This is a very common Rails convention when using HAML as a templating engine -- the parser won't recognize something like `app/views/posts/_form.html.haml` at the moment.