### PR TITLE
Use `@keyword` for ruby control and output statements

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,7 +1,7 @@
 [
   "="
   "-"
-] @operator
+] @keyword
 
 (attribute_name) @attribute
 (tag_name) @tag


### PR DESCRIPTION
Now, this is somewhat opinion based, but I also think this lines up with other tree sitter highlighting queries. Namely the [ERB highlight query](https://github.com/tree-sitter/tree-sitter-embedded-template/blob/master/queries/highlights.scm) which treats ruby injection points (like HAML's `-` and `=`) as keywords.